### PR TITLE
Fix error when no flat resources

### DIFF
--- a/Block/Sidebar.php
+++ b/Block/Sidebar.php
@@ -194,7 +194,7 @@ class Sidebar extends Template
             return (array)$category->getChildrenNodes();
         }
 
-        return $category->getChildren();
+        return $category->getChildrenCategories();
     }
 
     /**


### PR DESCRIPTION
Magento\Catalog\Model\Category::getChildren() returns a string of
comma-separated category ids. In order to get the category objects, the
method to use is ::getChildrenCategories().
